### PR TITLE
Feature/odxml to typescript test tools integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Windows/Installer/Resources
 macOS/Installer/Resources
 
 **/ssotme-win64-inno-msi/publish/**
+
+# test folder used to test locally
+test/

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -1164,7 +1164,7 @@ Seed Url: ");
                 // Prevent multiple concurrent processing of this event handler
                 if (isTargetUrlProcessing.Contains(this.TargetUrl) || result != null) return;
                 isTargetUrlProcessing.Add(this.TargetUrl);
-                this.conditionallyPopulateTranspiler(payload, "integrated-tools");
+                this.conditionallyPopulateTranspiler(payload, "remote-transpiler");
                 using var client = new HttpClient();
                 payload.TranspileRequest = new TranspileRequest();
                 payload.TranspileRequest.ZippedInputFileSet = this.inputFileSetXml.Zip();

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -948,7 +948,6 @@ Seed Url: ");
             var currentSSoTmeKey = SSOTMEKey.GetSSoTmeKey(this.runAs);
             result = null;
 
-            Console.WriteLine("add account holder reply to");
             this.AccountHolder.ReplyTo += AccountHolder_ReplyTo;
             this.AccountHolder.Init(currentSSoTmeKey.EmailAddress, currentSSoTmeKey.Secret);
 

--- a/Windows/Lib/Extensions/SSOTMEExtensions.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions.cs
@@ -1244,7 +1244,13 @@ namespace SSoTme.OST.Lib.Extensions
             // Check for common file locking error messages
             return ex.Message.Contains("being used by another process") ||
                    ex.Message.Contains("access is denied") ||
-                   ex.HResult == -2147024864; // 0x80070020 - ERROR_SHARING_VIOLATION
+        private const int ERROR_SHARING_VIOLATION_HRESULT = -2147024864; // 0x80070020
+        private static bool IsFileLockException(IOException ex)
+        {
+            // Check for common file locking error messages
+            return ex.Message.Contains("being used by another process") ||
+                   ex.Message.Contains("access is denied") ||
+                   ex.HResult == ERROR_SHARING_VIOLATION_HRESULT; // ERROR_SHARING_VIOLATION
         }
 
         public static void SplitFileSetXml(this string fileSetXml, String basePath)

--- a/Windows/Lib/Extensions/SSOTMEExtensions.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions.cs
@@ -1204,6 +1204,7 @@ namespace SSoTme.OST.Lib.Extensions
             int retryCount = 0;
             bool success = false;
             
+            IOException lastException = null;
             while (!success && retryCount < maxRetries)
             {
                 try
@@ -1217,18 +1218,27 @@ namespace SSoTme.OST.Lib.Extensions
                     }
                     success = true;
                 }
-                catch (IOException ex) when (retryCount < maxRetries - 1)
+                catch (IOException ex)
                 {
-                    // Only retry if it's a sharing violation or lock conflict
-                    if (IsFileLockException(ex))
+                    // Save the exception for potential re-throw
+                    lastException = ex;
+                    
+                    // Only retry if it's a sharing violation or lock conflict and we haven't reached max retries
+                    if (IsFileLockException(ex) && retryCount < maxRetries - 1)
                     {
                         retryCount++;
                         System.Threading.Thread.Sleep(retryDelayMs * retryCount);
                     }
+                    else if (!IsFileLockException(ex))
+                    {
+                        // Re-throw immediately if it's not a file lock exception
+                        throw;
+                    }
                     else
                     {
-                        // Re-throw if it's not a sharing violation
-                        throw;
+                        // This is a file lock exception but we've reached max retries
+                        // Will be thrown after the loop
+                        retryCount++;
                     }
                 }
             }
@@ -1236,6 +1246,11 @@ namespace SSoTme.OST.Lib.Extensions
             if (success)
             {
                 OnFileWritten(fileName);
+            }
+            else if (lastException != null)
+            {
+                // If all retries failed, throw the last exception with additional context
+                throw new IOException($"Failed to write to file '{fileName}' after {maxRetries} attempts: {lastException.Message}", lastException);
             }
         }
         
@@ -1436,8 +1451,48 @@ namespace SSoTme.OST.Lib.Extensions
 
         public static void SplitFileSetFile(this String fileSetFileName, String basePath)
         {
-            String fileContents = File.ReadAllText(fileSetFileName);
-            SplitFileSetXml(fileContents, false, basePath);
+            const int maxRetries = 5;
+            const int retryDelayMs = 100;
+            int retryCount = 0;
+            IOException lastException = null;
+            
+            while (retryCount < maxRetries)
+            {
+                try
+                {
+                    // Use FileShare.ReadWrite to allow other processes to access the file while we're reading it
+                    using (var fileStream = new FileStream(fileSetFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
+                    {
+                        String fileContents = streamReader.ReadToEnd();
+                        SplitFileSetXml(fileContents, false, basePath);
+                        return; // Success - exit the method
+                    }
+                }
+                catch (IOException ex)
+                {
+                    lastException = ex;
+                    // Only retry if it's a sharing violation or lock conflict
+                    if (IsFileLockException(ex))
+                    {
+                        retryCount++;
+                        if (retryCount < maxRetries)
+                        {
+                            System.Threading.Thread.Sleep(retryDelayMs * retryCount);
+                        }
+                    }
+                    else
+                    {
+                        throw; // Not a file lock exception, rethrow immediately
+                    }
+                }
+            }
+            
+            // If we've exhausted all retries, throw a meaningful exception
+            if (lastException != null)
+            {
+                throw new IOException($"Failed to read from file '{fileSetFileName}' after {maxRetries} attempts: {lastException.Message}", lastException);
+            }
         }
 
         public static string FullFromRelative(this string rootFullPath, string relativeFileName)

--- a/Windows/Lib/Extensions/SSOTMEExtensions.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions.cs
@@ -1239,11 +1239,6 @@ namespace SSoTme.OST.Lib.Extensions
             }
         }
         
-        private static bool IsFileLockException(IOException ex)
-        {
-            // Check for common file locking error messages
-            return ex.Message.Contains("being used by another process") ||
-                   ex.Message.Contains("access is denied") ||
         private const int ERROR_SHARING_VIOLATION_HRESULT = -2147024864; // 0x80070020
         private static bool IsFileLockException(IOException ex)
         {

--- a/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
@@ -998,11 +998,6 @@ namespace SSoTme.OST.Lib.Extensions
             }
         }
         
-        private static bool IsFileLockException(IOException ex)
-        {
-            // Check for common file locking error messages
-            return ex.Message.Contains("being used by another process") ||
-                   ex.Message.Contains("access is denied") ||
         private const int ERROR_SHARING_VIOLATION_HRESULT = -2147024864; // 0x80070020
         private static bool IsFileLockException(IOException ex)
         {

--- a/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
@@ -1003,7 +1003,13 @@ namespace SSoTme.OST.Lib.Extensions
             // Check for common file locking error messages
             return ex.Message.Contains("being used by another process") ||
                    ex.Message.Contains("access is denied") ||
-                   ex.HResult == -2147024864; // 0x80070020 - ERROR_SHARING_VIOLATION
+        private const int ERROR_SHARING_VIOLATION_HRESULT = -2147024864; // 0x80070020
+        private static bool IsFileLockException(IOException ex)
+        {
+            // Check for common file locking error messages
+            return ex.Message.Contains("being used by another process") ||
+                   ex.Message.Contains("access is denied") ||
+                   ex.HResult == ERROR_SHARING_VIOLATION_HRESULT; // ERROR_SHARING_VIOLATION
         }
 
         public static void SplitFileSetXml(this string fileSetXml, String basePath)

--- a/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
+++ b/Windows/Lib/Extensions/SSOTMEExtensions_core.cs
@@ -1,4 +1,4 @@
-﻿/*****************************
+/*****************************
 Project:    SSoTme - Open Source Tools (OST)
 Created By: EJ Alexandra - 2016
             An Abstract Level, llc
@@ -957,11 +957,53 @@ namespace SSoTme.OST.Lib.Extensions
         {
             var fi = new FileInfo(fileName);
             if (!fi.Directory.Exists) fi.Directory.Create();
-            using (StreamWriter sw = new StreamWriter(File.Open(fileName, FileMode.Create), new UTF8Encoding(false)))
+            
+            const int maxRetries = 5;
+            const int retryDelayMs = 100;
+            int retryCount = 0;
+            bool success = false;
+            
+            while (!success && retryCount < maxRetries)
             {
-                sw.Write(fileContents.UnwrapCDATA());
+                try
+                {
+                    // More permissive sharing mode - allow read and write access from other processes
+                    using (StreamWriter sw = new StreamWriter(File.Open(fileName, FileMode.Create, FileAccess.Write, FileShare.ReadWrite), new UTF8Encoding(false)))
+                    {
+                        sw.Write(fileContents.UnwrapCDATA());
+                        // Explicitly flush and close
+                        sw.Flush();
+                    }
+                    success = true;
+                }
+                catch (IOException ex) when (retryCount < maxRetries - 1)
+                {
+                    // Only retry if it's a sharing violation or lock conflict
+                    if (IsFileLockException(ex))
+                    {
+                        retryCount++;
+                        System.Threading.Thread.Sleep(retryDelayMs * retryCount);
+                    }
+                    else
+                    {
+                        // Re-throw if it's not a sharing violation
+                        throw;
+                    }
+                }
             }
-            OnFileWritten(fileName);
+            
+            if (success)
+            {
+                OnFileWritten(fileName);
+            }
+        }
+        
+        private static bool IsFileLockException(IOException ex)
+        {
+            // Check for common file locking error messages
+            return ex.Message.Contains("being used by another process") ||
+                   ex.Message.Contains("access is denied") ||
+                   ex.HResult == -2147024864; // 0x80070020 - ERROR_SHARING_VIOLATION
         }
 
         public static void SplitFileSetXml(this string fileSetXml, String basePath)


### PR DESCRIPTION
improvement for direct endpoint tools integration (ssotme -t url -i outputPath) :
- for remote transpiler integration, use fallback to populate transpiler name as 'remote-transpiler' to avoid nullReferenceException
- improve writeAllText and readAllText method that's used to write the cli output with more permissive sharing mode and apply retry mechanism to avoid error being thrown in the middle of writing the output