### PR TITLE
Development/feelixs

### DIFF
--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,10 +49,10 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026.04.03.1718";
+        public string CLI_VERSION = "2026-04-15.13.37";
 
         // url to the latest version of the transpiler-lister service
-        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-03-1641-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
+        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
         // name of the transpiler-lister tool that resolves to LATEST_TRANSPILERS_LISTER_URL. This tool also handles auth (sending request to magiclinks)
         public static readonly string TRANSPILERS_LISTER_TOOL_NAME = "cli-cloud-bridge";
 
@@ -879,9 +879,9 @@ namespace SSoTme.OST.Lib.CLIOptions
                     Console.WriteLine("\nERROR: Tool '{0}' does not exist.", this.transpiler);
                     Console.WriteLine("\nThe tool was not found locally or on the tools server.");
                     Console.WriteLine("\nTo see available tools, run:");
-                    Console.WriteLine("  effortless -list-tool-urls");
+                    Console.WriteLine("  effortless listToolUrls");
                     Console.WriteLine("\nTo add a new tool URL mapping, run:");
-                    Console.WriteLine("  effortless -set-tool-url <tool-name>=<url>");
+                    Console.WriteLine("  effortless setToolUrl <tool-name>=<url>");
                     Console.ForegroundColor = curColor;
                     this.SuppressTranspile = true;
                     return;
@@ -2094,9 +2094,9 @@ Seed Url: ");
                             ShowError("\nERROR: Tool '" + this.transpiler + "' does not exist.");
                             ShowError("\nThe tool was not found locally or on the tools server.");
                             ShowError("\nTo see available tools, run:");
-                            ShowError("  effortless -list-tool-urls");
+                            ShowError("  effortless listToolUrls");
                             ShowError("\nTo add a new tool URL mapping, run:");
-                            ShowError("  effortless -set-tool-url <tool-name>=<url>");
+                            ShowError("  effortless setToolUrl <tool-name>=<url>");
                             return -1;
                         }
                         else if (isTranspilerNotFound && this._suppressGenericToolNotFoundError)
@@ -3687,6 +3687,51 @@ Seed Url: ");
             payload.SaveCLIOptions(this);
             this.conditionallyPopulateTranspiler(payload, this.transpiler);
 
+            // -------- QUOTA: pre-transpile fetch --------
+            // Only attempt when this is an HTTP-direct transpiler we resolved from the remote registry
+            // (ResolvedToolName holds the canonical "author/package/tool" key). RabbitMQ-path and
+            // unresolved tools get no quota enforcement — the transpiler just runs.
+            // Null-safe: if any of these are missing, we skip silently.
+            string quotaTranspilerKey = null;
+            string quotaProjectUuid = null;
+            bool quotaAttempted = false;
+            if (!String.IsNullOrEmpty(this.jwt)
+                && !String.IsNullOrEmpty(this.ResolvedToolName)
+                && this.AICaptureProject != null
+                && !String.IsNullOrEmpty(this.AICaptureProject.SSoTmeProjectId)
+                && this.AICaptureProject.SSoTmeProjectId != Guid.Empty.ToString()
+                && !this.skipRemoteToolsLookup)
+            {
+                quotaTranspilerKey = this.ResolvedToolName;
+                quotaProjectUuid = this.AICaptureProject.SSoTmeProjectId;
+                try
+                {
+                    var quotaInfo = new SSoTme.OST.Lib.Services.MyEffortlessAPIService()
+                        .GetQuota(quotaProjectUuid, quotaTranspilerKey);
+                    if (quotaInfo != null && quotaInfo.Success)
+                    {
+                        quotaAttempted = true;
+                        // Inject params so the transpiler can check itself and surface a warning
+                        // in its output if it exceeds the available headroom.
+                        if (payload.CLIParams == null) payload.CLIParams = new List<string>();
+                        payload.CLIParams.Add($"available_quota={quotaInfo.AvailableNativeCount.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+                        payload.CLIParams.Add($"project_uuid={quotaProjectUuid}");
+                        payload.CLIParams.Add($"has_unlimited_quota={(quotaInfo.HasUnlimitedQuota ? "true" : "false")}");
+                        if (this.debug)
+                            Console.WriteLine($"DEBUG: Quota for {quotaTranspilerKey}: {quotaInfo.CurrentUsed}/{quotaInfo.Limit} (peak {quotaInfo.Peak}), project prev {quotaInfo.ThisProjectTranspilerPrevious}, available native {quotaInfo.AvailableNativeCount}");
+                    }
+                    else if (this.debug && quotaInfo != null)
+                    {
+                        Console.WriteLine($"DEBUG: getQuota failed: {quotaInfo.Error}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (this.debug) Console.WriteLine($"DEBUG: getQuota threw: {ex.Message}");
+                }
+            }
+            // -------- end QUOTA: pre-transpile fetch --------
+
             // Set LowerHyphenName for .zfs file creation after transpiler is populated
             if (payload.Transpiler != null && !string.IsNullOrEmpty(payload.Transpiler.Name))
             {
@@ -4098,6 +4143,57 @@ Seed Url: ");
                     // Preserve CLI debug flag from request to response
                     responsePayload.CLIDebug = this.debug;
                     this.result = responsePayload;
+
+                    // -------- QUOTA: post-transpile update --------
+                    // If we sent quota context on the way in, look for quota-report.json in the
+                    // returned FileSet, read the functionCount, and tell the bridge so it can
+                    // apply the weight + update the account's current/peak usage.
+                    if (quotaAttempted && !String.IsNullOrEmpty(quotaProjectUuid) && !String.IsNullOrEmpty(quotaTranspilerKey))
+                    {
+                        try
+                        {
+                            byte[] zippedOutput = responsePayload?.TranspileRequest?.ZippedOutputFileSet;
+                            if (zippedOutput != null && zippedOutput.Length > 0)
+                            {
+                                var outputFsXml = zippedOutput.UnzipToString();
+                                var outputFs = outputFsXml.ToFileSet();
+                                var report = outputFs?.FileSetFiles?.FirstOrDefault(f =>
+                                    f.RelativePath != null &&
+                                    f.RelativePath.Trim('/', '\\').Equals("quota-report.json", StringComparison.OrdinalIgnoreCase));
+                                if (report != null)
+                                {
+                                    var json = report.GetFileSetFileContents();
+                                    if (!String.IsNullOrWhiteSpace(json))
+                                    {
+                                        var parsed = Newtonsoft.Json.Linq.JObject.Parse(json);
+                                        var functionCountToken = parsed["functionCount"];
+                                        if (functionCountToken != null && functionCountToken.Type != Newtonsoft.Json.Linq.JTokenType.Null)
+                                        {
+                                            var newNativeCount = functionCountToken.Value<decimal>();
+                                            var updateResult = new SSoTme.OST.Lib.Services.MyEffortlessAPIService()
+                                                .UpdateQuota(quotaProjectUuid, quotaTranspilerKey, newNativeCount);
+                                            if (this.debug && updateResult != null)
+                                                Console.WriteLine($"DEBUG: updateQuota {(updateResult.Success ? "ok" : "failed")}: delta={updateResult.Delta}, newUsed={updateResult.NewUsed}, newPeak={updateResult.NewPeak}, error={updateResult.Error}");
+
+                                            // Surface a user-visible warning if the transpiler flagged this transpile as over-quota.
+                                            var exceededToken = parsed["quotaExceeded"];
+                                            if (exceededToken != null && exceededToken.Type == Newtonsoft.Json.Linq.JTokenType.Boolean && exceededToken.Value<bool>())
+                                            {
+                                                Console.ForegroundColor = ConsoleColor.Yellow;
+                                                Console.WriteLine($"WARNING: This transpile exceeded your quota ({newNativeCount} units generated). Transpile succeeded — please upgrade your plan to avoid future overage charges.");
+                                                Console.ResetColor();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            if (this.debug) Console.WriteLine($"DEBUG: updateQuota post-processing threw: {ex.Message}");
+                        }
+                    }
+                    // -------- end QUOTA: post-transpile update --------
                 }
                 catch (JsonException ex)
                 {

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,10 +49,10 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026-04-16.11.37";
+        public string CLI_VERSION = "2026-04-16.12.01";
 
         // url to the latest version of the transpiler-lister service
-        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-1132-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
+        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-1158-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
         // name of the transpiler-lister tool that resolves to LATEST_TRANSPILERS_LISTER_URL. This tool also handles auth (sending request to magiclinks)
         public static readonly string TRANSPILERS_LISTER_TOOL_NAME = "cli-cloud-bridge";
 

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,10 +49,10 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026-04-16.10.32";
+        public string CLI_VERSION = "2026-04-16.11.37";
 
         // url to the latest version of the transpiler-lister service
-        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "http://localhost:4422";
+        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-1132-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
         // name of the transpiler-lister tool that resolves to LATEST_TRANSPILERS_LISTER_URL. This tool also handles auth (sending request to magiclinks)
         public static readonly string TRANSPILERS_LISTER_TOOL_NAME = "cli-cloud-bridge";
 
@@ -3748,7 +3748,7 @@ Seed Url: ");
                         if (!quotaInfo.IsAllowedToTranspile)
                         {
                             Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine($"WARNING: Your account is over its quota limit ({quotaInfo.CurrentUsed}/{quotaInfo.Limit} units). This transpile will proceed but may incur overage charges. Please upgrade your plan.");
+                            Console.WriteLine($"WARNING: Your account is over its quota limit ({quotaInfo.CurrentUsed}/{quotaInfo.Limit} units). This transpile will proceed but may incur overage charges. Please contact us to upgrade your plan: https://effortlessapi.com/rulebook/waitlist");
                             Console.ResetColor();
                         }
 
@@ -4221,7 +4221,7 @@ Seed Url: ");
                                             if (exceededToken != null && exceededToken.Type == Newtonsoft.Json.Linq.JTokenType.Boolean && exceededToken.Value<bool>())
                                             {
                                                 Console.ForegroundColor = ConsoleColor.Yellow;
-                                                Console.WriteLine($"WARNING: This transpile exceeded your quota ({newNativeCount} units generated). Transpile succeeded; please upgrade your plan to avoid future overage charges https://effortlessapi.com/rulebook/waitlist.");
+                                                Console.WriteLine($"WARNING: This transpile exceeded your quota ({newNativeCount} units generated). Transpile succeeded; to avoid future overage charges please contact us to upgrade your plan: https://effortlessapi.com/rulebook/waitlist.");
                                                 Console.ResetColor();
                                             }
                                         }

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -52,7 +52,7 @@ namespace SSoTme.OST.Lib.CLIOptions
         public string CLI_VERSION = "2026-04-15.13.38";
 
         // url to the latest version of the transpiler-lister service
-        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
+        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
         // name of the transpiler-lister tool that resolves to LATEST_TRANSPILERS_LISTER_URL. This tool also handles auth (sending request to magiclinks)
         public static readonly string TRANSPILERS_LISTER_TOOL_NAME = "cli-cloud-bridge";
 

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,7 +49,7 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026-04-15.13.38";
+        public string CLI_VERSION = "2026-04-16.10.00";
 
         // url to the latest version of the transpiler-lister service
         public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
@@ -555,7 +555,20 @@ namespace SSoTme.OST.Lib.CLIOptions
                             this.targetUrl = urlFromFile;
                             this.transpiler = urlFromFile.SanitizeUrlForFilename();
                         }
-                        else if (this.transpiler.Contains("/"))
+
+                        // tool_urls.json override: if the raw transpiler name has a local URL override,
+                        // use it instead of the remote URL. ResolvedToolName stays set from remote_tools.
+                        if (!this.legacy && !String.IsNullOrEmpty(this._rawTranspilerArg))
+                        {
+                            var localOverride = this.TryGetUrlFromFileUrls(this._rawTranspilerArg);
+                            if (!String.IsNullOrEmpty(localOverride))
+                            {
+                                if (this.debug) Console.WriteLine($"DEBUG: tool_urls.json override for '{this._rawTranspilerArg}': {localOverride}");
+                                this.targetUrl = localOverride;
+                                this.ResolvedVersionLabel = $"{this._rawTranspilerArg} [user-set]";
+                            }
+                        }
+                        if (String.IsNullOrEmpty(this.targetUrl) && this.transpiler.Contains("/"))
                         {
                             if (!this.IsHttpUrl(this.transpiler))
                             {
@@ -625,7 +638,20 @@ namespace SSoTme.OST.Lib.CLIOptions
                                 this.targetUrl = urlFromFile;
                                 this.transpiler = urlFromFile.SanitizeUrlForFilename();
                             }
-                            else if (this.transpiler.Contains("/"))
+
+                            // tool_urls.json override: if the raw transpiler name has a local URL override,
+                            // use it instead of the remote URL. ResolvedToolName stays set from remote_tools.
+                            if (!this.legacy && !String.IsNullOrEmpty(this._rawTranspilerArg))
+                            {
+                                var localOverride = this.TryGetUrlFromFileUrls(this._rawTranspilerArg);
+                                if (!String.IsNullOrEmpty(localOverride))
+                                {
+                                    if (this.debug) Console.WriteLine($"DEBUG: tool_urls.json override for '{this._rawTranspilerArg}': {localOverride}");
+                                    this.targetUrl = localOverride;
+                                    this.ResolvedVersionLabel = $"{this._rawTranspilerArg} [user-set]";
+                                }
+                            }
+                            if (String.IsNullOrEmpty(this.targetUrl) && this.transpiler.Contains("/"))
                             {
                                 if (this.IsHttpUrl(this.transpiler))
                                 {

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -556,18 +556,7 @@ namespace SSoTme.OST.Lib.CLIOptions
                             this.transpiler = urlFromFile.SanitizeUrlForFilename();
                         }
 
-                        // tool_urls.json override: if the raw transpiler name has a local URL override,
-                        // use it instead of the remote URL. ResolvedToolName stays set from remote_tools.
-                        if (!this.legacy && !String.IsNullOrEmpty(this._rawTranspilerArg))
-                        {
-                            var localOverride = this.TryGetUrlFromFileUrls(this._rawTranspilerArg);
-                            if (!String.IsNullOrEmpty(localOverride))
-                            {
-                                if (this.debug) Console.WriteLine($"DEBUG: tool_urls.json override for '{this._rawTranspilerArg}': {localOverride}");
-                                this.targetUrl = localOverride;
-                                this.ResolvedVersionLabel = $"{this._rawTranspilerArg} [user-set]";
-                            }
-                        }
+                        this.TryApplyLocalToolUrlOverride();
                         if (String.IsNullOrEmpty(this.targetUrl) && this.transpiler.Contains("/"))
                         {
                             if (!this.IsHttpUrl(this.transpiler))
@@ -639,18 +628,7 @@ namespace SSoTme.OST.Lib.CLIOptions
                                 this.transpiler = urlFromFile.SanitizeUrlForFilename();
                             }
 
-                            // tool_urls.json override: if the raw transpiler name has a local URL override,
-                            // use it instead of the remote URL. ResolvedToolName stays set from remote_tools.
-                            if (!this.legacy && !String.IsNullOrEmpty(this._rawTranspilerArg))
-                            {
-                                var localOverride = this.TryGetUrlFromFileUrls(this._rawTranspilerArg);
-                                if (!String.IsNullOrEmpty(localOverride))
-                                {
-                                    if (this.debug) Console.WriteLine($"DEBUG: tool_urls.json override for '{this._rawTranspilerArg}': {localOverride}");
-                                    this.targetUrl = localOverride;
-                                    this.ResolvedVersionLabel = $"{this._rawTranspilerArg} [user-set]";
-                                }
-                            }
+                            this.TryApplyLocalToolUrlOverride();
                             if (String.IsNullOrEmpty(this.targetUrl) && this.transpiler.Contains("/"))
                             {
                                 if (this.IsHttpUrl(this.transpiler))
@@ -2450,6 +2428,20 @@ Seed Url: ");
 
             Console.WriteLine(logText);
             Console.ForegroundColor = curColor;
+        }
+
+        // Checks tool_urls.json for a local URL override for _rawTranspilerArg.
+        // If found, overrides targetUrl and sets the version label to [user-set].
+        // ResolvedToolName (from remote_tools) is preserved for quota tracking.
+        private void TryApplyLocalToolUrlOverride()
+        {
+            if (this.legacy || String.IsNullOrEmpty(this._rawTranspilerArg)) return;
+            var localOverride = this.TryGetUrlFromFileUrls(this._rawTranspilerArg);
+            if (String.IsNullOrEmpty(localOverride)) return;
+
+            if (this.debug) Console.WriteLine($"DEBUG: tool_urls.json override for '{this._rawTranspilerArg}': {localOverride}");
+            this.targetUrl = localOverride;
+            this.ResolvedVersionLabel = $"{this._rawTranspilerArg} [user-set]";
         }
 
         private string TryGetUrlFromFileUrls(string transpilerName)

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,10 +49,10 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026-04-16.10.00";
+        public string CLI_VERSION = "2026-04-16.10.32";
 
         // url to the latest version of the transpiler-lister service
-        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
+        public static readonly string LATEST_TRANSPILERS_LISTER_URL = "http://localhost:4422";
         // name of the transpiler-lister tool that resolves to LATEST_TRANSPILERS_LISTER_URL. This tool also handles auth (sending request to magiclinks)
         public static readonly string TRANSPILERS_LISTER_TOOL_NAME = "cli-cloud-bridge";
 
@@ -3738,9 +3738,20 @@ Seed Url: ");
                 {
                     var quotaInfo = new SSoTme.OST.Lib.Services.MyEffortlessAPIService()
                         .GetQuota(this.jwt, quotaProjectUuid, quotaTranspilerKey);
-                    if (quotaInfo != null && quotaInfo.Success)
+                    if (quotaInfo != null && quotaInfo.Success && !quotaInfo.Free)
                     {
                         quotaAttempted = true;
+
+                        // If the bridge says this transpile isn't allowed (no headroom even after
+                        // subtracting this project's share), warn the user but still proceed
+                        // per the warn-only enforcement policy.
+                        if (!quotaInfo.IsAllowedToTranspile)
+                        {
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            Console.WriteLine($"WARNING: Your account is over its quota limit ({quotaInfo.CurrentUsed}/{quotaInfo.Limit} units). This transpile will proceed but may incur overage charges. Please upgrade your plan.");
+                            Console.ResetColor();
+                        }
+
                         // Inject params so the transpiler can check itself and surface a warning
                         // in its output if it exceeds the available headroom.
                         if (payload.CLIParams == null) payload.CLIParams = new List<string>();
@@ -3748,7 +3759,7 @@ Seed Url: ");
                         payload.CLIParams.Add($"project_uuid={quotaProjectUuid}");
                         payload.CLIParams.Add($"has_unlimited_quota={(quotaInfo.HasUnlimitedQuota ? "true" : "false")}");
                         if (this.debug)
-                            Console.WriteLine($"DEBUG: Quota for {quotaTranspilerKey}: {quotaInfo.CurrentUsed}/{quotaInfo.Limit} (peak {quotaInfo.Peak}), project prev {quotaInfo.ThisProjectTranspilerPrevious}, available native {quotaInfo.AvailableNativeCount}");
+                            Console.WriteLine($"DEBUG: Quota for {quotaTranspilerKey}: {quotaInfo.CurrentUsed}/{quotaInfo.Limit} (peak {quotaInfo.Peak}), project prev {quotaInfo.ThisProjectTranspilerPrevious}, available native {quotaInfo.AvailableNativeCount}, allowed={quotaInfo.IsAllowedToTranspile}");
                     }
                     else if (this.debug)
                     {
@@ -4210,7 +4221,7 @@ Seed Url: ");
                                             if (exceededToken != null && exceededToken.Type == Newtonsoft.Json.Linq.JTokenType.Boolean && exceededToken.Value<bool>())
                                             {
                                                 Console.ForegroundColor = ConsoleColor.Yellow;
-                                                Console.WriteLine($"WARNING: This transpile exceeded your quota ({newNativeCount} units generated). Transpile succeeded — please upgrade your plan to avoid future overage charges.");
+                                                Console.WriteLine($"WARNING: This transpile exceeded your quota ({newNativeCount} units generated). Transpile succeeded; please upgrade your plan to avoid future overage charges https://effortlessapi.com/rulebook/waitlist.");
                                                 Console.ResetColor();
                                             }
                                         }

--- a/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
+++ b/Windows/Lib/CLIOptions/SSoTmeCLIHandler.cs
@@ -49,7 +49,7 @@ namespace SSoTme.OST.Lib.CLIOptions
     public partial class SSoTmeCLIHandler
     {
         // build scripts will make this match version from package.json
-        public string CLI_VERSION = "2026-04-15.13.37";
+        public string CLI_VERSION = "2026-04-15.13.38";
 
         // url to the latest version of the transpiler-lister service
         public static readonly string LATEST_TRANSPILERS_LISTER_URL = "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/";
@@ -1753,7 +1753,7 @@ Seed Url: ");
                     try
                     {
                         new MyEffortlessAPIService().RegisterProject(
-                            this.AICaptureProject.SSoTmeProjectId, this.AICaptureProject.Name);
+                            this.jwt, this.AICaptureProject.SSoTmeProjectId, this.AICaptureProject.Name);
                     }
                     catch (Exception ex) { if (this.debug) Console.WriteLine($"DEBUG: RegisterProject failed: {ex.Message}"); }
                 }
@@ -3695,6 +3695,10 @@ Seed Url: ");
             string quotaTranspilerKey = null;
             string quotaProjectUuid = null;
             bool quotaAttempted = false;
+            if (this.debug)
+            {
+                Console.WriteLine($"DEBUG: Quota guard check: jwt={!String.IsNullOrEmpty(this.jwt)}, ResolvedToolName={(this.ResolvedToolName ?? "<null>")}, AICaptureProject={(this.AICaptureProject != null ? "set" : "null")}, SSoTmeProjectId={(this.AICaptureProject?.SSoTmeProjectId ?? "<null>")}, skipRemoteToolsLookup={this.skipRemoteToolsLookup}");
+            }
             if (!String.IsNullOrEmpty(this.jwt)
                 && !String.IsNullOrEmpty(this.ResolvedToolName)
                 && this.AICaptureProject != null
@@ -3707,7 +3711,7 @@ Seed Url: ");
                 try
                 {
                     var quotaInfo = new SSoTme.OST.Lib.Services.MyEffortlessAPIService()
-                        .GetQuota(quotaProjectUuid, quotaTranspilerKey);
+                        .GetQuota(this.jwt, quotaProjectUuid, quotaTranspilerKey);
                     if (quotaInfo != null && quotaInfo.Success)
                     {
                         quotaAttempted = true;
@@ -3720,9 +3724,9 @@ Seed Url: ");
                         if (this.debug)
                             Console.WriteLine($"DEBUG: Quota for {quotaTranspilerKey}: {quotaInfo.CurrentUsed}/{quotaInfo.Limit} (peak {quotaInfo.Peak}), project prev {quotaInfo.ThisProjectTranspilerPrevious}, available native {quotaInfo.AvailableNativeCount}");
                     }
-                    else if (this.debug && quotaInfo != null)
+                    else if (this.debug)
                     {
-                        Console.WriteLine($"DEBUG: getQuota failed: {quotaInfo.Error}");
+                        Console.WriteLine($"DEBUG: getQuota returned null/failed (success={quotaInfo?.Success}, error={quotaInfo?.Error ?? "<null result>"})");
                     }
                 }
                 catch (Exception ex)
@@ -4171,7 +4175,7 @@ Seed Url: ");
                                         {
                                             var newNativeCount = functionCountToken.Value<decimal>();
                                             var updateResult = new SSoTme.OST.Lib.Services.MyEffortlessAPIService()
-                                                .UpdateQuota(quotaProjectUuid, quotaTranspilerKey, newNativeCount);
+                                                .UpdateQuota(this.jwt, quotaProjectUuid, quotaTranspilerKey, newNativeCount);
                                             if (this.debug && updateResult != null)
                                                 Console.WriteLine($"DEBUG: updateQuota {(updateResult.Success ? "ok" : "failed")}: delta={updateResult.Delta}, newUsed={updateResult.NewUsed}, newPeak={updateResult.NewPeak}, error={updateResult.Error}");
 

--- a/Windows/Lib/Services/MyEffortlessAPIService.cs
+++ b/Windows/Lib/Services/MyEffortlessAPIService.cs
@@ -323,13 +323,14 @@ namespace SSoTme.OST.Lib.Services
 
             try
             {
+                // Safe to interpolate unquoted: IsValidCliParam above guarantees no spaces, quotes,
+                // or -p tokens in any value. If the validator is ever loosened, these must be quoted.
                 return InvokeQuotaCall(
                     $"-p mode=getQuota -p jwt={jwt} -p project_uuid={projectUuid} -p transpiler_key={transpilerKey}");
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"[quota] GetQuota error: {ex.Message}");
-                return null;
+                return null; // caller logs via debug gate
             }
         }
 
@@ -351,14 +352,15 @@ namespace SSoTme.OST.Lib.Services
 
             try
             {
+                // Safe to interpolate unquoted: IsValidCliParam above guarantees no spaces, quotes,
+                // or -p tokens in any value. If the validator is ever loosened, these must be quoted.
                 var countStr = newNativeCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 return InvokeQuotaCall(
                     $"-p mode=updateQuota -p jwt={jwt} -p project_uuid={projectUuid} -p transpiler_key={transpilerKey} -p new_native_count={countStr}");
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"[quota] UpdateQuota error: {ex.Message}");
-                return null;
+                return null; // caller logs via debug gate
             }
         }
 
@@ -367,8 +369,6 @@ namespace SSoTme.OST.Lib.Services
         private static bool IsValidCliParam(string value)
         {
             if (string.IsNullOrEmpty(value)) return false;
-            // No spaces (would split the token), no quotes (would corrupt parsing),
-            // no -p prefix (would be interpreted as a new parameter).
             if (value.Contains(' ') || value.Contains('"') || value.Contains('\'')) return false;
             if (value.Contains("-p ")) return false;
             return true;
@@ -383,10 +383,9 @@ namespace SSoTme.OST.Lib.Services
                 if (string.IsNullOrEmpty(output)) return null;
                 return JsonConvert.DeserializeObject<QuotaResult>(output);
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"[quota] InvokeQuotaCall error: {ex.Message}");
-                return null;
+                return null; // caller logs via debug gate
             }
         }
 

--- a/Windows/Lib/Services/MyEffortlessAPIService.cs
+++ b/Windows/Lib/Services/MyEffortlessAPIService.cs
@@ -275,11 +275,10 @@ namespace SSoTme.OST.Lib.Services
 
         /// <summary>
         /// Checks if a project exists in the remote DB, and registers it if not.
-        /// Requires the user to be logged in (JWT).
+        /// Caller must pass the effective JWT (may be project-level from effortless.env or global).
         /// </summary>
-        public bool RegisterProject(string projectUuid, string projectName)
+        public bool RegisterProject(string jwt, string projectUuid, string projectName)
         {
-            var jwt = GetStoredJWTToken();
             if (string.IsNullOrEmpty(jwt))
                 return false;
 
@@ -309,11 +308,11 @@ namespace SSoTme.OST.Lib.Services
 
         /// <summary>
         /// Fetches the account's quota state plus this (project, transpiler)'s previous unit count.
+        /// Caller must pass the effective JWT (may be project-level from effortless.env or global).
         /// Returns null if we aren't logged in or the call fails — callers should treat that as "no quota enforcement".
         /// </summary>
-        public QuotaResult GetQuota(string projectUuid, string transpilerKey)
+        public QuotaResult GetQuota(string jwt, string projectUuid, string transpilerKey)
         {
-            var jwt = GetStoredJWTToken();
             if (string.IsNullOrEmpty(jwt)) return null;
             if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
 
@@ -336,10 +335,10 @@ namespace SSoTme.OST.Lib.Services
         /// Reports the post-transpile native count (e.g. function count for rulebook-to-postgres)
         /// back to the bridge so it can apply the weight, update the project's JSON blob, and
         /// adjust the account's current_monthly_quota_used / peak_monthly_quota_used.
+        /// Caller must pass the effective JWT (may be project-level from effortless.env or global).
         /// </summary>
-        public QuotaResult UpdateQuota(string projectUuid, string transpilerKey, decimal newNativeCount)
+        public QuotaResult UpdateQuota(string jwt, string projectUuid, string transpilerKey, decimal newNativeCount)
         {
-            var jwt = GetStoredJWTToken();
             if (string.IsNullOrEmpty(jwt)) return null;
             if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
 

--- a/Windows/Lib/Services/MyEffortlessAPIService.cs
+++ b/Windows/Lib/Services/MyEffortlessAPIService.cs
@@ -1201,6 +1201,10 @@ namespace SSoTme.OST.Lib.Services
         [JsonProperty("error")]
         public string Error { get; set; }
 
+        // True when the transpiler is not in the paid weights dict (free, no quota tracking).
+        [JsonProperty("free")]
+        public bool Free { get; set; }
+
         [JsonProperty("transpilerKey")]
         public string TranspilerKey { get; set; }
 
@@ -1223,6 +1227,11 @@ namespace SSoTme.OST.Lib.Services
         // (e.g. "functions" for rulebook-to-postgres). Pass this as available_quota to the transpiler.
         [JsonProperty("availableNativeCount")]
         public decimal AvailableNativeCount { get; set; }
+
+        // True if the transpile should proceed. False if account is over quota and this project's
+        // share doesn't free up enough headroom (availableNativeCount <= 0).
+        [JsonProperty("isAllowedToTranspile")]
+        public bool IsAllowedToTranspile { get; set; }
 
         [JsonProperty("hasUnlimitedQuota")]
         public bool HasUnlimitedQuota { get; set; }

--- a/Windows/Lib/Services/MyEffortlessAPIService.cs
+++ b/Windows/Lib/Services/MyEffortlessAPIService.cs
@@ -308,6 +308,74 @@ namespace SSoTme.OST.Lib.Services
         }
 
         /// <summary>
+        /// Fetches the account's quota state plus this (project, transpiler)'s previous unit count.
+        /// Returns null if we aren't logged in or the call fails — callers should treat that as "no quota enforcement".
+        /// </summary>
+        public QuotaResult GetQuota(string projectUuid, string transpilerKey)
+        {
+            var jwt = GetStoredJWTToken();
+            if (string.IsNullOrEmpty(jwt)) return null;
+            if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
+
+            try
+            {
+                var safeUuid = projectUuid.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
+                var safeKey = transpilerKey.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
+                var safeJwt = jwt.Replace("\"", "").Replace("'", "").Replace(" ", "");
+
+                return InvokeQuotaCall(
+                    $"-p mode=getQuota -p jwt=\"{safeJwt}\" -p project_uuid=\"{safeUuid}\" -p transpiler_key=\"{safeKey}\"");
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Reports the post-transpile native count (e.g. function count for rulebook-to-postgres)
+        /// back to the bridge so it can apply the weight, update the project's JSON blob, and
+        /// adjust the account's current_monthly_quota_used / peak_monthly_quota_used.
+        /// </summary>
+        public QuotaResult UpdateQuota(string projectUuid, string transpilerKey, decimal newNativeCount)
+        {
+            var jwt = GetStoredJWTToken();
+            if (string.IsNullOrEmpty(jwt)) return null;
+            if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
+
+            try
+            {
+                var safeUuid = projectUuid.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
+                var safeKey = transpilerKey.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
+                var safeJwt = jwt.Replace("\"", "").Replace("'", "").Replace(" ", "");
+                // Format invariantly so decimals don't get culture-localized (e.g. "," vs ".").
+                var countStr = newNativeCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+                return InvokeQuotaCall(
+                    $"-p mode=updateQuota -p jwt=\"{safeJwt}\" -p project_uuid=\"{safeUuid}\" -p transpiler_key=\"{safeKey}\" -p new_native_count={countStr}");
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private QuotaResult InvokeQuotaCall(string paramString)
+        {
+            try
+            {
+                var commandLine = $"{SSoTme.OST.Lib.CLIOptions.SSoTmeCLIHandler.TRANSPILERS_LISTER_TOOL_NAME} {paramString}";
+                var output = SSoTme.OST.Lib.CLIOptions.SSoTmeCLIHandler.InvokeToolAndGetOutput(commandLine, "auth-result.json");
+                if (string.IsNullOrEmpty(output)) return null;
+                return JsonConvert.DeserializeObject<QuotaResult>(output);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Refreshes the stored JWT token via the list-transpilers tool
         /// </summary>
         public bool RefreshToken()
@@ -1119,5 +1187,58 @@ namespace SSoTme.OST.Lib.Services
 
         [JsonProperty("exists")]
         public bool? Exists { get; set; }
+    }
+
+    /// <summary>
+    /// Deserialized response from cli-cloud-bridge's getQuota / updateQuota modes.
+    /// Fields populated depend on which call was made — the same class is used for both
+    /// to keep the calling code simple.
+    /// </summary>
+    public class QuotaResult
+    {
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        [JsonProperty("error")]
+        public string Error { get; set; }
+
+        [JsonProperty("transpilerKey")]
+        public string TranspilerKey { get; set; }
+
+        [JsonProperty("weight")]
+        public decimal Weight { get; set; }
+
+        [JsonProperty("limit")]
+        public decimal Limit { get; set; }
+
+        [JsonProperty("currentUsed")]
+        public decimal CurrentUsed { get; set; }
+
+        [JsonProperty("peak")]
+        public decimal Peak { get; set; }
+
+        [JsonProperty("thisProjectTranspilerPrevious")]
+        public decimal ThisProjectTranspilerPrevious { get; set; }
+
+        // getQuota only — the headroom available to this transpile, in the tool's native units
+        // (e.g. "functions" for rulebook-to-postgres). Pass this as available_quota to the transpiler.
+        [JsonProperty("availableNativeCount")]
+        public decimal AvailableNativeCount { get; set; }
+
+        [JsonProperty("hasUnlimitedQuota")]
+        public bool HasUnlimitedQuota { get; set; }
+
+        [JsonProperty("planName")]
+        public string PlanName { get; set; }
+
+        // updateQuota only — what the account's usage became after applying the delta.
+        [JsonProperty("newUsed")]
+        public decimal? NewUsed { get; set; }
+
+        [JsonProperty("newPeak")]
+        public decimal? NewPeak { get; set; }
+
+        [JsonProperty("delta")]
+        public decimal? Delta { get; set; }
     }
 }

--- a/Windows/Lib/Services/MyEffortlessAPIService.cs
+++ b/Windows/Lib/Services/MyEffortlessAPIService.cs
@@ -315,18 +315,20 @@ namespace SSoTme.OST.Lib.Services
         {
             if (string.IsNullOrEmpty(jwt)) return null;
             if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
+            if (!IsValidCliParam(projectUuid) || !IsValidCliParam(transpilerKey) || !IsValidCliParam(jwt))
+            {
+                Console.WriteLine("[quota] GetQuota: invalid characters in parameters, skipping");
+                return null;
+            }
 
             try
             {
-                var safeUuid = projectUuid.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
-                var safeKey = transpilerKey.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
-                var safeJwt = jwt.Replace("\"", "").Replace("'", "").Replace(" ", "");
-
                 return InvokeQuotaCall(
-                    $"-p mode=getQuota -p jwt=\"{safeJwt}\" -p project_uuid=\"{safeUuid}\" -p transpiler_key=\"{safeKey}\"");
+                    $"-p mode=getQuota -p jwt={jwt} -p project_uuid={projectUuid} -p transpiler_key={transpilerKey}");
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine($"[quota] GetQuota error: {ex.Message}");
                 return null;
             }
         }
@@ -341,22 +343,35 @@ namespace SSoTme.OST.Lib.Services
         {
             if (string.IsNullOrEmpty(jwt)) return null;
             if (string.IsNullOrEmpty(projectUuid) || string.IsNullOrEmpty(transpilerKey)) return null;
+            if (!IsValidCliParam(projectUuid) || !IsValidCliParam(transpilerKey) || !IsValidCliParam(jwt))
+            {
+                Console.WriteLine("[quota] UpdateQuota: invalid characters in parameters, skipping");
+                return null;
+            }
 
             try
             {
-                var safeUuid = projectUuid.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
-                var safeKey = transpilerKey.Replace("\"", "").Replace(" ", "").Replace("-p ", "");
-                var safeJwt = jwt.Replace("\"", "").Replace("'", "").Replace(" ", "");
-                // Format invariantly so decimals don't get culture-localized (e.g. "," vs ".").
                 var countStr = newNativeCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
-
                 return InvokeQuotaCall(
-                    $"-p mode=updateQuota -p jwt=\"{safeJwt}\" -p project_uuid=\"{safeUuid}\" -p transpiler_key=\"{safeKey}\" -p new_native_count={countStr}");
+                    $"-p mode=updateQuota -p jwt={jwt} -p project_uuid={projectUuid} -p transpiler_key={transpilerKey} -p new_native_count={countStr}");
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine($"[quota] UpdateQuota error: {ex.Message}");
                 return null;
             }
+        }
+
+        // Validates that a CLI param value won't corrupt ParseCommand's -p key=value parsing.
+        // Rejects whitespace, quotes, and the -p token rather than silently mutating.
+        private static bool IsValidCliParam(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return false;
+            // No spaces (would split the token), no quotes (would corrupt parsing),
+            // no -p prefix (would be interpreted as a new parameter).
+            if (value.Contains(' ') || value.Contains('"') || value.Contains('\'')) return false;
+            if (value.Contains("-p ")) return false;
+            return true;
         }
 
         private QuotaResult InvokeQuotaCall(string paramString)
@@ -368,8 +383,9 @@ namespace SSoTme.OST.Lib.Services
                 if (string.IsNullOrEmpty(output)) return null;
                 return JsonConvert.DeserializeObject<QuotaResult>(output);
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine($"[quota] InvokeQuotaCall error: {ex.Message}");
                 return null;
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
-  "version": "2026-04-16.11.37",
-  "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-1132-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
+  "version": "2026-04-16.12.01",
+  "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-1158-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssotme",
-  "version": "2026-04-15.13.39",
+  "version": "2026-04-16.10.00",
   "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
-  "version": "2026-04-16.10.00",
-  "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
+  "version": "2026-04-16.10.32",
+  "cloud_bridge_url": "http://localhost:4422",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
   "version": "2026-04-16.10.32",
-  "cloud_bridge_url": "http://localhost:4422",
+  "cloud_bridge_url": "http://host.docker.internal:4422",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
-  "version": "2026-04-16.10.32",
-  "cloud_bridge_url": "http://host.docker.internal:4422",
+  "version": "2026-04-16.11.37",
+  "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-1132-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssotme",
-  "version": "2026-04-15.13.37",
+  "version": "2026-04-15.13.38",
   "transpiler_lister_url": "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
-  "version": "2026-04-15.13.38",
-  "transpiler_lister_url": "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
+  "version": "2026-04-15.13.39",
+  "cloud_bridge_url": "https://ssotme-cli-cloud-bridge-v2026-04-16-0948-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssotme",
-  "version": "2026-04-10.02.54",
-  "transpiler_lister_url": "https://ssotme-cli-cloud-bridge-v2026-04-03-1641-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
+  "version": "2026-04-15.13.37",
+  "transpiler_lister_url": "https://ssotme-cli-cloud-bridge-v2026-04-15-1353-cmvbd4phczmeg.7pktzg2z971j0.cpln.app/",
   "dotnet": "8.0.410",
   "description": "",
   "bin": {

--- a/setup.py
+++ b/setup.py
@@ -106,19 +106,20 @@ class Installer:
         # Already valid or unknown format — return with hyphens replaced by dots
         return version.replace("-", ".")
 
-    def get_transpiler_lister_url(self):
+    @staticmethod
+    def get_transpiler_lister_url():
         print("Fetching transpiler lister URL from package.json")
         try:
             with open("package.json") as f:
                 j = json.loads(f.read())
-                url = j.get("transpiler_lister_url")
+                url = j.get("cloud_bridge_url")
                 if url:
                     print(f"Transpiler lister URL is '{url}'")
                     return url
                 else:
-                    print("No transpiler_lister_url found in package.json")
+                    print("No cloud_bridge_url found in package.json")
         except Exception as e:
-            print(f"Error reading transpiler_lister_url: {type(e).__name__}: {str(e)}")
+            print(f"Error reading cloud_bridge_url: {type(e).__name__}: {str(e)}")
         return None
 
     def get_supported_dotnet_version(self):
@@ -378,12 +379,12 @@ class Installer:
                 replacement = f'public string CLI_VERSION = "{self.get_package_version()}";'
                 new_contents = re.sub(pattern, replacement, contents)
 
-                transpiler_lister_url = self.get_transpiler_lister_url()
-                if transpiler_lister_url:
+                cloud_bridge_url = self.get_transpiler_lister_url()
+                if cloud_bridge_url:
                     pattern = r'public static readonly string LATEST_TRANSPILERS_LISTER_URL = ".*?";'
-                    replacement = f'public static readonly string LATEST_TRANSPILERS_LISTER_URL = "{transpiler_lister_url}";'
+                    replacement = f'public static readonly string LATEST_TRANSPILERS_LISTER_URL = "{cloud_bridge_url}";'
                     new_contents = re.sub(pattern, replacement, new_contents)
-                    print(f"Transpiler lister URL set to '{transpiler_lister_url}'")
+                    print(f"Transpiler lister URL set to '{cloud_bridge_url}'")
 
                 with open(fp, "w") as f:
                     f.write(new_contents)


### PR DESCRIPTION
  - Add pre/post-transpile quota checks against cli-cloud-bridge: fetch                                                                                
    headroom before transpile (inject available_quota/project_uuid/                                                                                    
    has_unlimited_quota into CLIParams), read quota-report.json from the                                                                               
    response, and report the native count back via updateQuota. Warn-only                                                                              
    enforcement; free tools and RabbitMQ-path transpiles are skipped.                                                                                  
  - Add QuotaResult DTO and GetQuota/UpdateQuota on MyEffortlessAPIService.                                                                            
    Validate JWT/project_uuid/transpiler_key with IsValidCliParam (reject                                                                              
    whitespace/quotes/`-p `) instead of silently mutating.                                                                                             
  - Change RegisterProject to take an explicit jwt so callers can pass a                                                                               
    project-level token from effortless.env.                                                                                                           
  - Add tool_urls.json local override: TryApplyLocalToolUrlOverride()                                                                                  
    lets a user-set URL win over the remote-resolved one while preserving                                                                              
    ResolvedToolName for quota tracking.                                                                                                               
  - Rename package.json `transpiler_lister_url` → `cloud_bridge_url`;                                                                                  
    bump CLI_VERSION and LATEST_TRANSPILERS_LISTER_URL to 2026-04-16.                                                                                  
  - Update "tool not found" hints to new subcommand syntax                                                                                             
    (`listToolUrls` / `setToolUrl`).   